### PR TITLE
rename function if it's a reserved word

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,18 @@ function createWrapper(name, withCallback) {
     + 'if (lastType === "function") return $$__fn__$$.apply(self, arguments)\n'
    : ''
 
-  return '(function ' + (name || '') + '() {\n'
+  name = name ? ~[
+    'abstract', 'arguments', 'boolean', 'break', 'byte', 'case', 'catch', 'char',
+    'class', 'const', 'continue', 'debugger', 'default', 'delete', 'do', 'double',
+    'else', 'enum', 'eval', 'export', 'extends', 'false', 'final', 'finally', 'float',
+    'for', 'function', 'goto', 'if', 'implements', 'import', 'in', 'instanceof', 'int',
+    'interface', 'let', 'long', 'native', 'new', 'null', 'package', 'private', 'protected',
+    'public', 'return', 'short', 'static', 'super', 'switch', 'synchronized', 'this',
+    'throw', 'throws', 'transient', 'true', 'try', 'typeof', 'var', 'void', 'volatile',
+    'while', 'with', 'yield'
+  ].indexOf(name) ? '$$' + name : name : ''
+
+  return '(function ' + name + '() {\n'
     + 'var self = this\n'
     + 'var len = arguments.length\n'
     + withCallback


### PR DESCRIPTION
so, for whatever reason I was working with a node module that had a `NODE_SET_METHOD(obj, "delete", deleteFn);`

as a result thenify would not be able to export that function, ever -- just because of it's name. no workarounds

it's pretty unlikely that anyone will run into this -- but here it is just in case.. I'm convinced the only way to set a function name to a reserved word, is with C++

cheers