### PR TITLE
use es6-promise polyfill rather than native-or-bluebird

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 
-var Promise = require('native-or-bluebird')
+var Promise = require('es6-promise').Promise
 var assert = require('assert')
 
 module.exports = thenify

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "thenables/thenify",
   "dependencies": {
-    "native-or-bluebird": "1"
+    "es6-promise": "^3.0.2"
   },
   "devDependencies": {
     "bluebird": "3.1.1",


### PR DESCRIPTION
@jonathanong Using bluebird or native promises creates implicit behavioral dependencies, particularly in npm 3 where you can install some unrelated package and without changing any code, your application's behavior changes.